### PR TITLE
Feat/menu nav

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
-<!doctype html>
-<html lang="en">
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -1,5 +1,6 @@
 import { CartItemsType, MenuCategoryType } from "../types";
 import MenuCategory from "./MenuCategory";
+import MenuNav from "./MenuNav";
 import Navbar from "./Navbar";
 import { Link } from "react-router-dom";
 
@@ -11,17 +12,27 @@ type MenuProps = {
 
 const Menu = ({ menuItems, cartItems, handleCartItems }: MenuProps) => {
   return (
-    <>
+    <div>
       <Navbar>
         <Link to="cart">
           <p className="text-lg">Cart Items ({cartItems.length})</p>
         </Link>
       </Navbar>
-      <main className="max-w-[1640px] mx-auto px-6">
-        <MenuCategory menuItems={menuItems} handleCartItems={handleCartItems} />
+      <main className="lg:flex">
+        <div className="lg:w-[18%]">
+          <MenuNav />
+        </div>
+        <div className="lg:w-[82%] mx-auto px-6">
+          <MenuCategory
+            menuItems={menuItems}
+            handleCartItems={handleCartItems}
+          />
+        </div>
       </main>
-    </>
+    </div>
   );
 };
 
 export default Menu;
+
+// max-w-[1640px] mx-auto px-6

--- a/src/components/MenuCategory.tsx
+++ b/src/components/MenuCategory.tsx
@@ -14,8 +14,8 @@ const MenuCategory = ({ menuItems, handleCartItems }: MenuCategoryProps) => {
   return (
     <>
       {Object.entries(menuItems).map(([category, items]) => (
-        <section key={category} className="my-12" id={category}>
-          <h2 className="text-3xl font-bold my-4">
+        <section key={category} className="py-8" id={category}>
+          <h2 className="text-xl md:text-2xl lg:text-3xl font-bold pb-5 pt-8">
             {category.replace(/([a-z])([A-Z])/g, "$1 $2").toUpperCase()}
           </h2>
           <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-x-8 gap-y-10 ">

--- a/src/components/MenuCategory.tsx
+++ b/src/components/MenuCategory.tsx
@@ -14,11 +14,11 @@ const MenuCategory = ({ menuItems, handleCartItems }: MenuCategoryProps) => {
   return (
     <>
       {Object.entries(menuItems).map(([category, items]) => (
-        <section key={category} className="my-12">
+        <section key={category} className="my-12" id={category}>
           <h2 className="text-3xl font-bold my-4">
             {category.replace(/([a-z])([A-Z])/g, "$1 $2").toUpperCase()}
           </h2>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-x-8 gap-y-10 ">
+          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-x-8 gap-y-10 ">
             {items.map((item) => (
               <MenuItem
                 key={item.id}

--- a/src/components/MenuItem.tsx
+++ b/src/components/MenuItem.tsx
@@ -18,7 +18,7 @@ const MenuItem = ({ item, handleCartItems }: MenuItemProps) => {
       </Link>
       <div className="px-3 py-5">
         <Link to={`/details/${item.id}`}>
-          <h3 className="text-2xl font-bold mb-1">{item.name}</h3>
+          <h3 className="text-[23px] font-bold mb-1">{item.name}</h3>
         </Link>
         <p className="text-gray-600 mb-2">
           {item.description.length >= 105
@@ -29,13 +29,13 @@ const MenuItem = ({ item, handleCartItems }: MenuItemProps) => {
           ${item.price} | {item.calories} cals
         </p>
         <div className="flex justify-evenly mt-8">
-          <Link to={`/details/${item.id}`}>
+          <Link to={`/details/${item.id}`} className="w-[50%]">
             <button className="border-2 border-orange-500 text-orange-500 font-bold rounded-full px-4 py-2">
               Details
             </button>
           </Link>
           <button
-            className="bg-orange-500 text-white font-bold rounded-full px-4 py-2"
+            className="bg-orange-500 text-white font-bold rounded-full w-[50%]"
             onClick={() =>
               handleCartItems({
                 id: Date.now(),

--- a/src/components/MenuItem.tsx
+++ b/src/components/MenuItem.tsx
@@ -8,7 +8,7 @@ type MenuItemProps = {
 
 const MenuItem = ({ item, handleCartItems }: MenuItemProps) => {
   return (
-    <div className="border rounded-3xl shadow-lg hover:scale-105 duration-300">
+    <div className="border rounded-3xl shadow-lg hover:scale-105 duration-300 max-w-[480px]">
       <Link to={`/details/${item.id}`}>
         <img
           className="w-full h-[260px] object-cover rounded-t-3xl"
@@ -22,7 +22,7 @@ const MenuItem = ({ item, handleCartItems }: MenuItemProps) => {
         </Link>
         <p className="text-gray-600 mb-2">
           {item.description.length >= 105
-            ? `${item.description.slice(0, 100)}...`
+            ? `${item.description.slice(0, 80)}...`
             : item.description}
         </p>
         <p className="text-gray-600">

--- a/src/components/MenuNav.tsx
+++ b/src/components/MenuNav.tsx
@@ -3,7 +3,7 @@ const navLinks = ["burgers", "chickenSandwiches", "drinks"];
 const MenuNav = () => {
   return (
     <nav className="hidden lg:block sticky top-0">
-      <ul className="inline-flex flex-col font-medium mt-10 gap-y-4">
+      <ul className="inline-flex flex-col font-medium mt-10 pt-10 gap-y-4">
         {navLinks.map((link) => (
           <a
             className="p-2 mx-7 cursor-pointer text-lg capitalize "

--- a/src/components/MenuNav.tsx
+++ b/src/components/MenuNav.tsx
@@ -1,0 +1,20 @@
+const navLinks = ["burgers", "chickenSandwiches", "drinks"];
+
+const MenuNav = () => {
+  return (
+    <nav className="hidden lg:block sticky top-0">
+      <ul className="inline-flex flex-col font-medium mt-10 gap-y-4">
+        {navLinks.map((link) => (
+          <a
+            className="p-2 mx-7 cursor-pointer text-lg capitalize "
+            href={`#${link}`}
+          >
+            <li key={link}>{link.replace(/([a-z])([A-Z])/g, "$1 $2")}</li>
+          </a>
+        ))}
+      </ul>
+    </nav>
+  );
+};
+
+export default MenuNav;

--- a/src/components/MenuNav.tsx
+++ b/src/components/MenuNav.tsx
@@ -6,7 +6,7 @@ const MenuNav = () => {
       <ul className="inline-flex flex-col font-medium mt-10 pt-10 gap-y-4">
         {navLinks.map((link) => (
           <a
-            className="p-2 mx-7 cursor-pointer text-lg capitalize "
+            className="p-2 mx-4 cursor-pointer text-lg capitalize hover:underline"
             href={`#${link}`}
           >
             <li key={link}>{link.replace(/([a-z])([A-Z])/g, "$1 $2")}</li>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -6,7 +6,7 @@ type NavbarProps = {
 
 const Navbar = ({ children }: NavbarProps) => {
   return (
-    <nav className="flex justify-around items-center py-3 bg-orange-500 text-white">
+    <nav className="flex justify-around items-center py-3 bg-orange-500 text-white sticky top-0 z-10">
       <Logo />
       {children}
     </nav>


### PR DESCRIPTION
### What is the feature?
Display a side nav for easy navigation when the screen is a certain width. (Desktop/Laptop)

### What is the solution?
Created a separate nav component and render in Menu component. Needed to adjust styling to display in a certain width. Sticky side bar and nav bar are included using the sticky and top: 0.

### What areas of the site does it impact?
This impacts the menu page when the user is in a large display.

### How to test?
Cypress can be used to test if the users are able to see the side nav on large screen and able to navigate user to clicked category food.

## Other Notes
This is going to get rid of the 6th issue and getting rid of search feature. The side bar works well with navigating user's to a type of food they're looking for

closes #6 