### PR TITLE
Feat/remove items

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ function App() {
     drinks: [],
   });
   const [cartItems, setCartItems] = useState<CartItemsType[] | []>([]);
+  console.log(cartItems);
 
   const handleCartItems = (newItem: CartItemsType) => {
     setCartItems([...cartItems, newItem]);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { CartItemsType, MenuCategoryType } from "./types";
-import Menu from "./components/Menu";
+import Menu from "./pages/Menu";
 import { Route, Routes } from "react-router-dom";
 import NotFound from "./components/NotFound";
 import DetailsPage from "./pages/DetailsPage";
@@ -17,7 +17,6 @@ function App() {
     drinks: [],
   });
   const [cartItems, setCartItems] = useState<CartItemsType[] | []>([]);
-  console.log(cartItems);
 
   const handleCartItems = (newItem: CartItemsType) => {
     setCartItems([...cartItems, newItem]);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,13 @@ function App() {
     setCartItems([...cartItems, newItem]);
   };
 
+  const removeCartItem = (itemId: number) => {
+    const filtered = cartItems.filter((items) => {
+      return items.id !== itemId;
+    });
+    setCartItems(filtered);
+  };
+
   useEffect(() => {
     const fetchMenu = async () => {
       const response = await fetch(`${url}/menu`);
@@ -52,7 +59,12 @@ function App() {
           />
         }
       />
-      <Route path="cart" element={<CartPage cartItems={cartItems} />} />
+      <Route
+        path="cart"
+        element={
+          <CartPage cartItems={cartItems} removeCartItem={removeCartItem} />
+        }
+      />
       <Route path="*" element={<NotFound />} />
     </Routes>
   );

--- a/src/components/CartEmptyMessage.tsx
+++ b/src/components/CartEmptyMessage.tsx
@@ -1,0 +1,5 @@
+const CartEmptyMessage = () => {
+  return <p className="text-center">Bag is empty</p>;
+};
+
+export default CartEmptyMessage;

--- a/src/components/CartItems.tsx
+++ b/src/components/CartItems.tsx
@@ -1,0 +1,44 @@
+import { CartItemsType } from "../types";
+
+type CartItemsProps = {
+  cartItems: CartItemsType[];
+  removeCartItem: (itemId: number) => void;
+};
+
+const CartItems = ({ cartItems, removeCartItem }: CartItemsProps) => {
+  return (
+    <>
+      {cartItems.map((item) => (
+        <div
+          key={item.id}
+          className="flex items-center justify-between px-4 md:px-8 lg:px-12"
+        >
+          <div className="flex items-center">
+            <img
+              src={item.img}
+              alt={item.name}
+              className="w-[50px] h-[50px] md:w-[100px] md:h-[100px] rounded-full object-cover mr-2 md:mr-5"
+            />
+            <p className="font-semibold text-sm md:text-lg ">{item.name}</p>
+          </div>
+          <div className="flex items-center gap-x-3 md:gap-x-8">
+            <p className="font-semibold text-sm sm:text-base">
+              Qt: {item.quantity}
+            </p>
+            <p className="font-bold text-sm sm:text-base">
+              ${Number(item.price * item.quantity).toFixed(2)}
+            </p>
+            <button
+              className="bg-red-500 text-white w-[25px] sm:w-[30px] sm:py-1 rounded-full font-bold hover:bg-red-800"
+              onClick={() => removeCartItem(item.id)}
+            >
+              X
+            </button>
+          </div>
+        </div>
+      ))}
+    </>
+  );
+};
+
+export default CartItems;

--- a/src/components/DetailsFooter.tsx
+++ b/src/components/DetailsFooter.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from "react-router-dom";
 import { CartItemsType } from "../types";
+import { useState } from "react";
 
 type DetailsFooterProps = {
   name: string;
@@ -14,6 +15,7 @@ const DetailsFooter = ({
   img,
   handleCartItems,
 }: DetailsFooterProps) => {
+  const [quantity, setQuantity] = useState(1);
   const navigate = useNavigate();
 
   return (
@@ -21,6 +23,15 @@ const DetailsFooter = ({
       <p className="text-lg">
         <span className="font-bold">Total: </span>${price}
       </p>
+      <select
+        className="border"
+        value={quantity}
+        onChange={(e) => setQuantity(Number(e.target.value))}
+      >
+        <option value={1}>1</option>
+        <option value={2}>2</option>
+        <option value={3}>3</option>
+      </select>
       <button
         className="bg-orange-500 text-white font-bold text-lg rounded-full px-14 py-2"
         onClick={() => {
@@ -29,6 +40,7 @@ const DetailsFooter = ({
             name,
             price,
             img,
+            quantity,
           }),
             navigate(-1);
         }}

--- a/src/components/MenuItem.tsx
+++ b/src/components/MenuItem.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router-dom";
 import { CartItemsType, MenuItemType } from "../types";
+import { useState } from "react";
 
 type MenuItemProps = {
   item: MenuItemType;
@@ -7,6 +8,8 @@ type MenuItemProps = {
 };
 
 const MenuItem = ({ item, handleCartItems }: MenuItemProps) => {
+  const [quantity, setQuantity] = useState(1);
+
   return (
     <div className="border rounded-3xl shadow-lg hover:scale-105 duration-300 max-w-[480px]">
       <Link to={`/details/${item.id}`}>
@@ -34,6 +37,15 @@ const MenuItem = ({ item, handleCartItems }: MenuItemProps) => {
               Details
             </button>
           </Link>
+          <select
+            className="border"
+            value={quantity}
+            onChange={(e) => setQuantity(Number(e.target.value))}
+          >
+            <option value={1}>1</option>
+            <option value={2}>2</option>
+            <option value={3}>3</option>
+          </select>
           <button
             className="bg-orange-500 text-white font-bold rounded-full w-[50%]"
             onClick={() =>
@@ -42,6 +54,7 @@ const MenuItem = ({ item, handleCartItems }: MenuItemProps) => {
                 name: item.name,
                 price: item.price,
                 img: item.image_url,
+                quantity: quantity,
               })
             }
           >

--- a/src/components/MenuItem.tsx
+++ b/src/components/MenuItem.tsx
@@ -32,13 +32,13 @@ const MenuItem = ({ item, handleCartItems }: MenuItemProps) => {
           ${item.price} | {item.calories} cals
         </p>
         <div className="flex justify-evenly mt-8">
-          <Link to={`/details/${item.id}`} className="w-[50%]">
+          <Link to={`/details/${item.id}`} className="">
             <button className="border-2 border-orange-500 text-orange-500 font-bold rounded-full px-4 py-2">
               Details
             </button>
           </Link>
           <select
-            className="border"
+            className="border rounded-full pl-4 w-[18%]"
             value={quantity}
             onChange={(e) => setQuantity(Number(e.target.value))}
           >
@@ -47,7 +47,7 @@ const MenuItem = ({ item, handleCartItems }: MenuItemProps) => {
             <option value={3}>3</option>
           </select>
           <button
-            className="bg-orange-500 text-white font-bold rounded-full w-[50%]"
+            className="bg-orange-500 text-white font-bold rounded-full w-[40%]"
             onClick={() =>
               handleCartItems({
                 id: Date.now(),

--- a/src/components/MenuNav.tsx
+++ b/src/components/MenuNav.tsx
@@ -8,8 +8,9 @@ const MenuNav = () => {
           <a
             className="p-2 mx-4 cursor-pointer text-lg capitalize hover:underline"
             href={`#${link}`}
+            key={link}
           >
-            <li key={link}>{link.replace(/([a-z])([A-Z])/g, "$1 $2")}</li>
+            <li>{link.replace(/([a-z])([A-Z])/g, "$1 $2")}</li>
           </a>
         ))}
       </ul>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -6,7 +6,7 @@ type NavbarProps = {
 
 const Navbar = ({ children }: NavbarProps) => {
   return (
-    <nav className="flex justify-around items-center py-3 bg-orange-500 text-white sticky top-0 z-10">
+    <nav className="flex justify-between items-center py-3 px-6 bg-orange-500 text-white sticky top-0 z-10">
       <Logo />
       {children}
     </nav>

--- a/src/components/PageBackMenu.tsx
+++ b/src/components/PageBackMenu.tsx
@@ -1,0 +1,13 @@
+import { Link } from "react-router-dom";
+
+const PageBackMenu = () => {
+  return (
+    <div className="w-full text-white bg-black font-semibold p-2 px-6 text-lg flex items-center">
+      <Link to="/">
+        <span className="mr-3">&lt;</span> Menu
+      </Link>
+    </div>
+  );
+};
+
+export default PageBackMenu;

--- a/src/components/TotalCost.tsx
+++ b/src/components/TotalCost.tsx
@@ -1,0 +1,23 @@
+import { CartItemsType } from "../types";
+
+type TotalCostProps = {
+  cartItems: CartItemsType[];
+};
+
+const TotalCost = ({ cartItems }: TotalCostProps) => {
+  const getTotalCost = (arr: CartItemsType[]) => {
+    const total = arr.reduce((acc, current) => {
+      return (acc += current.price * current.quantity);
+    }, 0);
+    return Number(total).toFixed(2);
+  };
+
+  return (
+    <div className="shadow-md min-w-[300px] border flex justify-around items-center h-[70px] font-bold md:text-lg w-[30%] rounded-2xl">
+      <h4>Subtotal:</h4>
+      <p>${getTotalCost(cartItems)}</p>
+    </div>
+  );
+};
+
+export default TotalCost;

--- a/src/pages/CartPage.tsx
+++ b/src/pages/CartPage.tsx
@@ -1,6 +1,10 @@
 import { Link } from "react-router-dom";
 import Navbar from "../components/Navbar";
 import { CartItemsType } from "../types";
+import PageBackMenu from "../components/PageBackMenu";
+import TotalCost from "../components/TotalCost";
+import CartEmptyMessage from "../components/CartEmptyMessage";
+import CartItems from "../components/CartItems";
 
 type CartPageProps = {
   cartItems: CartItemsType[];
@@ -8,69 +12,23 @@ type CartPageProps = {
 };
 
 const CartPage = ({ cartItems, removeCartItem }: CartPageProps) => {
-  const getTotalCost = (arr: CartItemsType[]) => {
-    const total = arr.reduce((acc, current) => {
-      return (acc += current.price * current.quantity);
-    }, 0);
-    return Number(total).toFixed(2);
-  };
-
   return (
     <section>
       <Navbar children={undefined} />
-      <div className="w-full text-white bg-black font-semibold p-2 px-6 text-lg flex items-center">
-        <Link to="/">
-          <span className="mr-3">&lt;</span> Menu
-        </Link>
-      </div>
+      <PageBackMenu />
       <h2 className="my-10 px-6 font-bold text-2xl md:text-3xl lg:text-4xl">
         Your Bag
       </h2>
       <div className="max-w-[1640px] mx-auto px-6 pb-10 flex flex-col lg:flex-row">
         <div className="flex flex-col gap-7 justify-evenly shadow-md border lg:mr-10 lg:w-[70%] py-8 rounded-2xl">
           {cartItems.length === 0 ? (
-            <p className="text-center">Bag is empty</p>
+            <CartEmptyMessage />
           ) : (
-            <>
-              {cartItems.map((item) => (
-                <div
-                  key={item.id}
-                  className="flex items-center justify-between px-4 md:px-8 lg:px-12"
-                >
-                  <div className="flex items-center">
-                    <img
-                      src={item.img}
-                      alt={item.name}
-                      className="w-[50px] h-[50px] md:w-[100px] md:h-[100px] rounded-full object-cover mr-2 md:mr-5"
-                    />
-                    <p className="font-semibold text-sm md:text-lg ">
-                      {item.name}
-                    </p>
-                  </div>
-                  <div className="flex items-center gap-x-3 md:gap-x-8">
-                    <p className="font-semibold text-sm sm:text-base">
-                      Qt: {item.quantity}
-                    </p>
-                    <p className="font-bold text-sm sm:text-base">
-                      ${Number(item.price * item.quantity).toFixed(2)}
-                    </p>
-                    <button
-                      className="bg-red-500 text-white w-[25px] sm:w-[30px] sm:py-1 rounded-full font-bold hover:bg-red-800"
-                      onClick={() => removeCartItem(item.id)}
-                    >
-                      X
-                    </button>
-                  </div>
-                </div>
-              ))}
-            </>
+            <CartItems cartItems={cartItems} removeCartItem={removeCartItem} />
           )}
         </div>
         <div className="flex flex-col-reverse lg:flex-col mt-10 lg:mt-0 gap-10 ">
-          <div className="shadow-md min-w-[300px] border flex justify-around items-center h-[70px] font-bold md:text-lg w-[30%] rounded-2xl">
-            <h4>Subtotal:</h4>
-            <p>${getTotalCost(cartItems)}</p>
-          </div>
+          <TotalCost cartItems={cartItems} />
           <Link to="/">
             <button className="border border-orange-500 text-orange-500 font-bold rounded-full w-full p-4">
               Add more items

--- a/src/pages/CartPage.tsx
+++ b/src/pages/CartPage.tsx
@@ -10,7 +10,7 @@ type CartPageProps = {
 const CartPage = ({ cartItems, removeCartItem }: CartPageProps) => {
   const getTotalCost = (arr: CartItemsType[]) => {
     const total = arr.reduce((acc, current) => {
-      return (acc += current.price);
+      return acc + current.price * current.quantity;
     }, 0);
     return Number(total).toFixed(2);
   };
@@ -46,6 +46,7 @@ const CartPage = ({ cartItems, removeCartItem }: CartPageProps) => {
                     <p className="font-semibold md:text-lg ">{item.name}</p>
                   </div>
                   <div className="flex items-center gap-x-8">
+                    <p>Quantity: {item.quantity}</p>
                     <p className="font-bold">${item.price}</p>
                     <button
                       className="bg-red-500 text-white w-[30px] py-1 rounded-full font-bold hover:bg-red-800"

--- a/src/pages/CartPage.tsx
+++ b/src/pages/CartPage.tsx
@@ -4,9 +4,10 @@ import { CartItemsType } from "../types";
 
 type CartPageProps = {
   cartItems: CartItemsType[];
+  removeCartItem: (itemId: number) => void;
 };
 
-const CartPage = ({ cartItems }: CartPageProps) => {
+const CartPage = ({ cartItems, removeCartItem }: CartPageProps) => {
   const getTotalCost = (arr: CartItemsType[]) => {
     const total = arr.reduce((acc, current) => {
       return (acc += current.price);
@@ -28,13 +29,13 @@ const CartPage = ({ cartItems }: CartPageProps) => {
       <div className="max-w-[1640px] mx-auto px-6 pb-10 flex flex-col lg:flex-row">
         <div className="flex flex-col gap-7 justify-evenly shadow-md border lg:mr-10 lg:w-[70%] py-8 rounded-2xl">
           {cartItems.length === 0 ? (
-            <p className="text-center">Add an item to view order</p>
+            <p className="text-center">Bag is empty</p>
           ) : (
             <>
               {cartItems.map((item) => (
                 <div
                   key={item.id}
-                  className="flex items-center justify-between px-4 md:px-8 lg:px-12"
+                  className="flex items-center justify-between gap-x-2 px-4 md:px-8 lg:px-12"
                 >
                   <div className="flex items-center">
                     <img
@@ -44,7 +45,15 @@ const CartPage = ({ cartItems }: CartPageProps) => {
                     />
                     <p className="font-semibold md:text-lg ">{item.name}</p>
                   </div>
-                  <p>${item.price}</p>
+                  <div className="flex items-center gap-x-8">
+                    <p className="font-bold">${item.price}</p>
+                    <button
+                      className="bg-red-500 text-white w-[30px] py-1 rounded-full font-bold hover:bg-red-800"
+                      onClick={() => removeCartItem(item.id)}
+                    >
+                      X
+                    </button>
+                  </div>
                 </div>
               ))}
             </>

--- a/src/pages/CartPage.tsx
+++ b/src/pages/CartPage.tsx
@@ -35,7 +35,7 @@ const CartPage = ({ cartItems, removeCartItem }: CartPageProps) => {
               {cartItems.map((item) => (
                 <div
                   key={item.id}
-                  className="flex items-center justify-between gap-x-2 px-4 md:px-8 lg:px-12"
+                  className="flex items-center justify-between px-4 md:px-8 lg:px-12"
                 >
                   <div className="flex items-center">
                     <img
@@ -43,15 +43,19 @@ const CartPage = ({ cartItems, removeCartItem }: CartPageProps) => {
                       alt={item.name}
                       className="w-[50px] h-[50px] md:w-[100px] md:h-[100px] rounded-full object-cover mr-2 md:mr-5"
                     />
-                    <p className="font-semibold md:text-lg ">{item.name}</p>
+                    <p className="font-semibold text-sm md:text-lg ">
+                      {item.name}
+                    </p>
                   </div>
-                  <div className="flex items-center gap-x-8">
-                    <p>Quantity: {item.quantity}</p>
-                    <p className="font-bold">
+                  <div className="flex items-center gap-x-3 md:gap-x-8">
+                    <p className="font-semibold text-sm sm:text-base">
+                      Qt: {item.quantity}
+                    </p>
+                    <p className="font-bold text-sm sm:text-base">
                       ${Number(item.price * item.quantity).toFixed(2)}
                     </p>
                     <button
-                      className="bg-red-500 text-white w-[30px] py-1 rounded-full font-bold hover:bg-red-800"
+                      className="bg-red-500 text-white w-[25px] sm:w-[30px] sm:py-1 rounded-full font-bold hover:bg-red-800"
                       onClick={() => removeCartItem(item.id)}
                     >
                       X
@@ -63,7 +67,7 @@ const CartPage = ({ cartItems, removeCartItem }: CartPageProps) => {
           )}
         </div>
         <div className="flex flex-col-reverse lg:flex-col mt-10 lg:mt-0 gap-10 ">
-          <div className="shadow-md min-w-[300px] border flex justify-around items-center h-[70px] font-bold text-lg w-[30%] rounded-2xl">
+          <div className="shadow-md min-w-[300px] border flex justify-around items-center h-[70px] font-bold md:text-lg w-[30%] rounded-2xl">
             <h4>Subtotal:</h4>
             <p>${getTotalCost(cartItems)}</p>
           </div>

--- a/src/pages/CartPage.tsx
+++ b/src/pages/CartPage.tsx
@@ -10,7 +10,7 @@ type CartPageProps = {
 const CartPage = ({ cartItems, removeCartItem }: CartPageProps) => {
   const getTotalCost = (arr: CartItemsType[]) => {
     const total = arr.reduce((acc, current) => {
-      return acc + current.price * current.quantity;
+      return (acc += current.price * current.quantity);
     }, 0);
     return Number(total).toFixed(2);
   };
@@ -47,7 +47,9 @@ const CartPage = ({ cartItems, removeCartItem }: CartPageProps) => {
                   </div>
                   <div className="flex items-center gap-x-8">
                     <p>Quantity: {item.quantity}</p>
-                    <p className="font-bold">${item.price}</p>
+                    <p className="font-bold">
+                      ${Number(item.price * item.quantity).toFixed(2)}
+                    </p>
                     <button
                       className="bg-red-500 text-white w-[30px] py-1 rounded-full font-bold hover:bg-red-800"
                       onClick={() => removeCartItem(item.id)}

--- a/src/pages/Menu.tsx
+++ b/src/pages/Menu.tsx
@@ -1,7 +1,7 @@
 import { CartItemsType, MenuCategoryType } from "../types";
-import MenuCategory from "./MenuCategory";
-import MenuNav from "./MenuNav";
-import Navbar from "./Navbar";
+import MenuCategory from "../components/MenuCategory";
+import MenuNav from "../components/MenuNav";
+import Navbar from "../components/Navbar";
 import { Link } from "react-router-dom";
 
 type MenuProps = {
@@ -34,5 +34,3 @@ const Menu = ({ menuItems, cartItems, handleCartItems }: MenuProps) => {
 };
 
 export default Menu;
-
-// max-w-[1640px] mx-auto px-6

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,4 +21,5 @@ export type CartItemsType = {
   name: string;
   price: number;
   img: string;
+  quantity: number;
 };


### PR DESCRIPTION
### What is the feature?
Users can now select the quantity amount of a selected item (Up to 3 items).  Cart page displays the quantity amount and re-calculates the total cost depending on the amount of items. Users can now remove the items in the cart page.

### What is the solution?
Added a new key value pair to store the quantity amount when a user adds a new item to bag. The default is going to be one and that value is then sent to the cart page to display the amount and multiply the quantity amount with the item cost. 

To remove an item, a function has been added in app component that filters the items that have not been selected upon clicking the X button. It uses the id of the items to find which item to remove.

### What areas of the site does it impact?
This impacts the cart page and the details page.

### How to test?
Cypress can be used to test if the users are able to select a certain quantity of an item and to check if the total cost adds up with the bag order. Test the remove button of an item.

## Other Notes
This will close the 10th issue

closes #10 